### PR TITLE
Add missing inline declaration

### DIFF
--- a/include/math/tmpl_arctan_asymptotic_ldouble.h
+++ b/include/math/tmpl_arctan_asymptotic_ldouble.h
@@ -106,7 +106,7 @@
 #define A5 (-9.09090909090909090909090909090E-02L)
 
 /*  Long double precision asymptotic expansion for the arctangent function.   */
-long double tmpl_LDouble_Arctan_Asymptotic(long double x)
+inline long double tmpl_LDouble_Arctan_Asymptotic(long double x)
 {
     /*  Declare necessary variables.                                          */
     const long double z = 1.0L / x;


### PR DESCRIPTION
Hi Ryan,

This addresses a multiple definition error I discovered while building with inline functions enabled.

Best regards,
Ty